### PR TITLE
Support automatic default commandPath for arduino-cli

### DIFF
--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import * as WinReg from "winreg";
 import * as util from "../common/util";
 
-import { resolveArduinoPath, validateArduinoPath } from "../common/platform";
+import { getDefaultCommandPath, resolveArduinoPath } from "../common/platform";
 
 import { VscodeSettings } from "./vscodeSettings";
 
@@ -52,9 +52,6 @@ export class ArduinoSettings implements IArduinoSettings {
         await this.tryGetDefaultBaudRate();
         if (platform === "win32") {
             await this.updateWindowsPath();
-            if (this._commandPath === "") {
-                this._commandPath = "arduino_debug.exe";
-            }
         } else if (platform === "linux") {
             if (util.directoryExistsSync(path.join(this._arduinoPath, "portable"))) {
                 this._packagePath = path.join(this._arduinoPath, "portable");
@@ -70,10 +67,6 @@ export class ArduinoSettings implements IArduinoSettings {
                 }
             } else {
                 this._sketchbookPath = path.join(process.env.HOME, "Arduino");
-            }
-
-            if (this._commandPath === "") {
-                this._commandPath = "arduino";
             }
         } else if (platform === "darwin") {
             if (util.directoryExistsSync(path.join(this._arduinoPath, "portable"))) {
@@ -91,12 +84,8 @@ export class ArduinoSettings implements IArduinoSettings {
             } else {
                 this._sketchbookPath = path.join(process.env.HOME, "Documents/Arduino");
             }
-
-            if (this._commandPath === "") {
-                this._commandPath = "/Contents/MacOS/Arduino";
-            }
         }
-    }
+     }
 
     public get arduinoPath(): string {
         return this._arduinoPath;
@@ -131,11 +120,16 @@ export class ArduinoSettings implements IArduinoSettings {
     }
 
     public get commandPath(): string {
+        let commandPath = this._commandPath;
+        if (commandPath === "") {
+            commandPath = getDefaultCommandPath(this.isArduinoCli);
+        }
+
         const platform = os.platform();
         if (platform === "darwin") {
-            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), path.normalize(this._commandPath));
+            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), path.normalize(commandPath));
         } else {
-            return path.join(this._arduinoPath, path.normalize(this._commandPath));
+            return path.join(this._arduinoPath, path.normalize(commandPath));
         }
     }
 

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -22,6 +22,10 @@ export function findFile(fileName: string, cwd: string): string {
     return internalSysLib.findFile(fileName, cwd);
 }
 
+export function getDefaultCommandPath(isArduinoCli: boolean): string {
+    return internalSysLib.getDefaultCommandPath(isArduinoCli);
+}
+
 export function getExecutableFileName(fileName: string): string {
     if (isWindows) {
         return `${fileName}.exe`;

--- a/src/common/sys/darwin.ts
+++ b/src/common/sys/darwin.ts
@@ -19,7 +19,7 @@ export function resolveArduinoPath(): string {
 }
 
 export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), isArduinoCli ? "arduino-cli" : "/Contents/MacOS/Arduino"));
+    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), getDefaultCommandPath(isArduinoCli)));
 
 }
 
@@ -37,4 +37,8 @@ export function findFile(fileName: string, cwd: string): string {
         // Ignore the errors.
     }
     return pathString;
+}
+
+export function getDefaultCommandPath(isArduinoCli: boolean): string {
+    return isArduinoCli ? "arduino-cli" : "/Contents/MacOS/Arduino";
 }

--- a/src/common/sys/linux.ts
+++ b/src/common/sys/linux.ts
@@ -21,7 +21,7 @@ export function resolveArduinoPath(): string {
 }
 
 export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(arduinoPath, isArduinoCli ? "arduino-cli" : "arduino"));
+    return fileExistsSync(path.join(arduinoPath, getDefaultCommandPath(isArduinoCli)));
 }
 
 export function findFile(fileName: string, cwd: string): string {
@@ -38,4 +38,8 @@ export function findFile(fileName: string, cwd: string): string {
         // Ignore the errors.
     }
     return pathString;
+}
+
+export function getDefaultCommandPath(isArduinoCli: boolean): string {
+    return isArduinoCli ? "arduino-cli" : "arduino";
 }

--- a/src/common/sys/win32.ts
+++ b/src/common/sys/win32.ts
@@ -28,7 +28,7 @@ export async function resolveArduinoPath() {
 }
 
 export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(arduinoPath, isArduinoCli ? "arduino-cli.exe" : "arduino_debug.exe"));
+    return fileExistsSync(path.join(arduinoPath, getDefaultCommandPath(isArduinoCli)));
 
 }
 
@@ -44,4 +44,8 @@ export function findFile(fileName: string, cwd: string): string {
         // Ignore the errors.
     }
     return result;
+}
+
+export function getDefaultCommandPath(isArduinoCli: boolean): string {
+    return isArduinoCli ? "arduino-cli.exe" : "arduino_debug.exe";
 }


### PR DESCRIPTION
commandPath for arduino-cli mode should auto-default to the arduino-cli executable if not otherwise specified.

- Move the switch between IDE/CLI behavior to a common location in the platform specific files to reduce duplication.
- Move the commandPath fallback to default behavior to runtime rather than init, so it will respect changes to isArduinoCli flag as well as changes such as clearing the user specified commandPath