### PR TITLE
Improve the messaging of the 'arduino.isArduinoCli' setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,10 +442,10 @@
       "type": "object",
       "title": "Arduino configuration",
       "properties": {
-        "arduino.isArduinoCli" : {
+        "arduino.isArduinoCli": {
           "type": "boolean",
           "default": false,
-          "description": "Arduino-CLI installed instead of more common Arduino GUI"
+          "markdownDescription": "Arduino-CLI installed instead of more common Arduino GUI.  `#arduino.path#` must be set, as there is no default path for 'arduino-cli'. (Requires a restart after change)"
         },
         "arduino.path": {
           "type": "string",


### PR DESCRIPTION
- Specify that for now 'arduino.path' must be set, since there is no automatic resolution
- Specify that a restart will be requried for this command to fully take affect